### PR TITLE
simplify: remove redundant params, name magic constants, eliminate per-frame allocs

### DIFF
--- a/bus.go
+++ b/bus.go
@@ -83,7 +83,7 @@ func GetBusData(baseURL string, stop int) ([]Bus, StopInfo, error) {
 	q.Set("ReturnList", "StopPointName,LineName,EstimatedTime,Towards,Latitude,Longitude")
 	u.RawQuery = q.Encode()
 
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
 	if err != nil {
 		panic(err)
 	}

--- a/display_linux.go
+++ b/display_linux.go
@@ -110,8 +110,10 @@ func openFB(dev string) (*fbDevice, error) {
 	bpp := int(vinfo.BitsPerPixel)
 
 	stride := width * bpp / 8
-	if raw, err := os.ReadFile("/sys/class/graphics/fb0/stride"); err == nil {
-		if n, err := strconv.Atoi(strings.TrimSpace(string(raw))); err == nil && n > 0 {
+	raw, err := os.ReadFile("/sys/class/graphics/fb0/stride")
+	if err == nil {
+		n, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+		if err == nil && n > 0 {
 			stride = n
 		}
 	}

--- a/render.go
+++ b/render.go
@@ -16,10 +16,19 @@ import (
 )
 
 const (
-	slotHeight     = 130
-	scrollDuration = 5 * time.Second
-	border         = 80
+	slotHeight      = 130
+	scrollDuration  = 5 * time.Second
+	border          = 80
+	busListY        = 150 // Y baseline of the first bus row, below the header band
+	maxVisibleBuses = 3   // bus rows shown when not animating
 )
+
+// smoothstep maps t ∈ [0,1] to [0,1] with zero first-derivative at both
+// endpoints, producing an ease-in/ease-out curve: 3t² − 2t³.
+// See https://en.wikipedia.org/wiki/Smoothstep
+func smoothstep(t float64) float64 {
+	return t * t * (3 - 2*t)
+}
 
 func newFace(size float64) (xfont.Face, error) {
 	ttf, err := opentype.Parse(gobold.TTF)
@@ -96,9 +105,11 @@ func (r *renderer) advanceScroll(liveBuses []Bus, now time.Time) (buses []Bus, y
 			r.scrollStart = time.Time{}
 			r.scrollBuses = nil
 		} else {
+			// t runs 0→1 over scrollDuration. yOffset starts at slotHeight
+			// (buses appear one row below) and eases to 0 (final position),
+			// sliding the list upward with a smooth ease-in/ease-out curve.
 			t := float64(elapsed) / float64(scrollDuration)
-			t = t * t * (3 - 2*t) // smoothstep
-			yOffset = int(float64(slotHeight) * (1 - t))
+			yOffset = int(float64(slotHeight) * (1 - smoothstep(t)))
 		}
 	}
 
@@ -118,17 +129,18 @@ func (r *renderer) advanceScroll(liveBuses []Bus, now time.Time) (buses []Bus, y
 // scrollLayout returns the drawing parameters for the bus list.
 func scrollLayout(firstIdx, yOffset int, animating bool) (startIdx, startY, maxBuses int) {
 	if !animating {
-		return firstIdx, 150, 3
+		return firstIdx, busListY, maxVisibleBuses
 	}
 	startIdx = firstIdx
 	if firstIdx > 0 {
 		startIdx = firstIdx - 1
 	}
-	return startIdx, 150 - (slotHeight - yOffset), 4
+	return startIdx, busListY - (slotHeight - yOffset), maxVisibleBuses + 1
 }
 
 // drawBuses renders the bus arrival rows onto img.
-func drawBuses(img *image.RGBA, face xfont.Face, buses []Bus, startIdx, startY, maxBuses, w, border int, animating bool) {
+func drawBuses(img *image.RGBA, face xfont.Face, buses []Bus, startIdx, startY, maxBuses int, animating bool) {
+	w := img.Bounds().Max.X
 	y := startY
 	count := 0
 	for _, b := range buses[startIdx:] {
@@ -139,11 +151,13 @@ func drawBuses(img *image.RGBA, face xfont.Face, buses []Bus, startIdx, startY, 
 		if d < 0 && !animating {
 			continue
 		}
-		drawString(img, face, border, y, b.Number, image.White)
-		etaStr := d.String()
+		var etaStr string
 		if d < 0 {
 			etaStr = "Due"
+		} else {
+			etaStr = d.String()
 		}
+		drawString(img, face, border, y, b.Number, image.White)
 		rightX := w - border - measureString(face, etaStr)
 		drawString(img, face, rightX, y, etaStr, image.White)
 		y += slotHeight
@@ -152,7 +166,7 @@ func drawBuses(img *image.RGBA, face xfont.Face, buses []Bus, startIdx, startY, 
 }
 
 // drawFooter renders the weather string and clock onto the bottom of img.
-func drawFooter(img *image.RGBA, face xfont.Face, weatherStr string, border int) {
+func drawFooter(img *image.RGBA, face xfont.Face, weatherStr string) {
 	y := img.Bounds().Max.Y - face.Metrics().Descent.Ceil()
 	w := img.Bounds().Max.X
 	drawString(img, face, border, y, weatherStr, image.White)
@@ -160,10 +174,13 @@ func drawFooter(img *image.RGBA, face xfont.Face, weatherStr string, border int)
 	drawString(img, face, w-border-measureString(face, timeStr), y, timeStr, image.White)
 }
 
-var headerColour = image.NewUniform(color.Gray{Y: 180})
+var (
+	headerColour = image.NewUniform(color.Gray{Y: 180})
+	blackUniform = image.NewUniform(color.Black)
+)
 
 // drawHeader renders the stop name and direction onto the top of img.
-func drawHeader(img *image.RGBA, tt *timeTable, f xfont.Face, border int) {
+func drawHeader(img *image.RGBA, tt *timeTable, f xfont.Face) {
 	info := tt.getStopInfo()
 	header := info.Name
 	if info.Towards != "" {
@@ -188,21 +205,20 @@ func (r *renderer) renderFrame(img *image.RGBA, bigFace, smallFace xfont.Face, t
 		r.scrollBuses = nil
 	}
 
-	draw.Draw(img, img.Bounds(), image.NewUniform(color.Black), image.Point{}, draw.Src)
+	draw.Draw(img, img.Bounds(), blackUniform, image.Point{}, draw.Src)
 
 	buses, yOffset, animating := r.advanceScroll(tt.getBuses(), time.Now())
 	startIdx, startY, maxBuses := scrollLayout(firstIdxOf(buses), yOffset, animating)
-	drawBuses(img, bigFace, buses, startIdx, startY, maxBuses, w, border, animating)
+	drawBuses(img, bigFace, buses, startIdx, startY, maxBuses, animating)
 
 	// Blank header and footer bands so scrolling bus rows cannot overwrite them.
 	const headerH, footerH = 40, 40
-	black := image.NewUniform(color.Black)
-	draw.Draw(img, image.Rect(0, 0, w, headerH), black, image.Point{}, draw.Src)
-	draw.Draw(img, image.Rect(0, h-footerH, w, h), black, image.Point{}, draw.Src)
+	draw.Draw(img, image.Rect(0, 0, w, headerH), blackUniform, image.Point{}, draw.Src)
+	draw.Draw(img, image.Rect(0, h-footerH, w, h), blackUniform, image.Point{}, draw.Src)
 
 	// Header and footer drawn last so they always appear on top of bus rows.
-	drawHeader(img, tt, smallFace, border)
-	drawFooter(img, smallFace, weatherStr, border)
+	drawHeader(img, tt, smallFace)
+	drawFooter(img, smallFace, weatherStr)
 
 	return animating
 }


### PR DESCRIPTION
## Summary
- Remove `border` param from `drawHeader`/`drawFooter` — it is a package constant, not a variable
- Remove `w` and `border` params from `drawBuses` — `w` is derived from `img.Bounds()` inside the function
- Merge double `d < 0` checks in `drawBuses`; only call `d.String()` in the else branch (avoids wasted alloc for overdue buses)
- Replace 3× per-frame `image.NewUniform(color.Black)` with a package-level `blackUniform`
- Name magic literals: `150` → `busListY`, `3` → `maxVisibleBuses`, `4` → `maxVisibleBuses+1`
- Extract `smoothstep` as a named function
- Unwrap double inline-if for stride reading in `openFB` (project style: call then check on separate lines)
- Use `http.MethodGet` instead of string literal `"GET"`

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] HTTP preview renders correctly at `http://localhost:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)